### PR TITLE
fix: upgrade skill references redirected link

### DIFF
--- a/skills/next-upgrade/SKILL.md
+++ b/skills/next-upgrade/SKILL.md
@@ -13,7 +13,7 @@ Upgrade the current project to the latest Next.js version following official mig
 1. **Detect current version**: Read `package.json` to identify the current Next.js version and related dependencies (React, React DOM, etc.)
 
 2. **Fetch the latest upgrade guide**: Use WebFetch to get the official upgrade documentation:
-   - Codemods: https://nextjs.org/docs/app/building-your-application/upgrading/codemods
+   - Codemods: https://nextjs.org/docs/app/guides/upgrading/codemods
    - Version-specific guides (adjust version as needed):
      - https://nextjs.org/docs/app/guides/upgrading/version-16 
      - https://nextjs.org/docs/app/guides/upgrading/version-15

--- a/skills/next-upgrade/SKILL.md
+++ b/skills/next-upgrade/SKILL.md
@@ -15,8 +15,9 @@ Upgrade the current project to the latest Next.js version following official mig
 2. **Fetch the latest upgrade guide**: Use WebFetch to get the official upgrade documentation:
    - Codemods: https://nextjs.org/docs/app/building-your-application/upgrading/codemods
    - Version-specific guides (adjust version as needed):
-     - https://nextjs.org/docs/app/building-your-application/upgrading/version-15
-     - https://nextjs.org/docs/app/building-your-application/upgrading/version-14
+     - https://nextjs.org/docs/app/guides/upgrading/version-16 
+     - https://nextjs.org/docs/app/guides/upgrading/version-15
+     - https://nextjs.org/docs/app/guides/upgrading/version-14
 
 3. **Determine upgrade path**: Based on current version, identify which migration steps apply. For major version jumps, upgrade incrementally (e.g., 13 → 14 → 15).
 


### PR DESCRIPTION
Agents are inferring the links for the upgrade guides incorrectly. 

See https://github.com/vercel/front/pull/61545 for more context

- [x] fix codemods links too