### PR TITLE
Update file-conventions.md renaming proxyConfig to config according to docs

### DIFF
--- a/skills/next-best-practices/file-conventions.md
+++ b/skills/next-best-practices/file-conventions.md
@@ -123,7 +123,7 @@ export function proxy(request: NextRequest) {
   return NextResponse.next();
 }
 
-export const proxyConfig = {
+export const config = {
   matcher: ['/dashboard/:path*', '/api/:path*'],
 };
 ```
@@ -131,7 +131,7 @@ export const proxyConfig = {
 | Version | File | Export | Config |
 |---------|------|--------|--------|
 | v14-15 | `middleware.ts` | `middleware()` | `config` |
-| v16+ | `proxy.ts` | `proxy()` | `proxyConfig` |
+| v16+ | `proxy.ts` | `proxy()` | `config` |
 
 **Migration**: Run `npx @next/codemod@latest upgrade` to auto-rename.
 


### PR DESCRIPTION
according to the docs [file-conventions proxy matcher](https://nextjs.org/docs/pages/api-reference/file-conventions/proxy#matcher) the config export is not named proxyConfig but config