### PR TITLE
docs(proxy): fix config export name in proxy.ts examples

### DIFF
--- a/skills/next-best-practices/file-conventions.md
+++ b/skills/next-best-practices/file-conventions.md
@@ -123,7 +123,7 @@ export function proxy(request: NextRequest) {
   return NextResponse.next();
 }
 
-export const proxyConfig = {
+export const config = {
   matcher: ['/dashboard/:path*', '/api/:path*'],
 };
 ```
@@ -131,7 +131,7 @@ export const proxyConfig = {
 | Version | File | Export | Config |
 |---------|------|--------|--------|
 | v14-15 | `middleware.ts` | `middleware()` | `config` |
-| v16+ | `proxy.ts` | `proxy()` | `proxyConfig` |
+| v16+ | `proxy.ts` | `proxy()` | `config` |
 
 **Migration**: Run `npx @next/codemod@latest upgrade` to auto-rename.
 


### PR DESCRIPTION
## Problem

The `proxy.ts` file-convention documentation (and migration guide from `middleware.ts`) showed `proxyConfig` as the name for the config export:

```ts
export const proxyConfig = {
  matcher: ['/dashboard/:path*'],
};
```

This is incorrect. Next.js statically analyzes the file for an export named `config` regardless of whether the file is named `middleware.ts` or `proxy.ts`. When `proxyConfig` is used instead, the matcher is silently ignored and the proxy function runs on every request, bypassing path exclusions entirely.

## Fix

Correct the config export name to `config` in all `proxy.ts` examples:

```diff
- export const proxyConfig = {
+ export const config = {
    matcher: ['/dashboard/:path*'],
  };
```

## How I found this

We migrated a Next.js 16 app from `middleware.ts` to `proxy.ts` following the documented convention. After deploying, our Kubernetes readiness probe (`/api/health`) started returning 401 — a path that was explicitly excluded in the matcher. Debugging the compiled Turbopack output revealed that the matcher was not being picked up at all, because the export was named `proxyConfig` instead of `config`. Renaming the export fixed the issue immediately.