### PR TITLE
feat(routes): add documentation for Favicon API route handlers

### DIFF
--- a/skills/next-best-practices/SKILL.md
+++ b/skills/next-best-practices/SKILL.md
@@ -75,6 +75,7 @@ See [route-handlers.md](./route-handlers.md) for:
 - GET handler conflicts with `page.tsx`
 - Environment behavior (no React DOM)
 - When to use vs Server Actions
+- Favicon API route handlers
 
 ## Metadata & OG Images
 

--- a/skills/next-best-practices/route-handlers.md
+++ b/skills/next-best-practices/route-handlers.md
@@ -144,3 +144,29 @@ return new Response(stream, {
 
 **Prefer Server Actions** for mutations triggered from your UI.
 **Use Route Handlers** for external integrations and public APIs.
+
+---
+
+# Favicon API Routes
+
+In complex monorepo environments, static `favicon.ico` files can sometimes cause build or routing issues. If converting a favicon to an API route, ensure it supports the standard request methods for web crawlers.
+
+```tsx
+// Bad: Converting favicon to API route but only exporting GET
+// app/favicon.ico/route.ts
+export async function GET() { 
+  return fetchFaviconFile() 
+}
+
+// Good: Explicit handlers for GET, HEAD, and OPTIONS to remain safe for crawlers
+// app/favicon.ico/route.ts
+export async function GET() { 
+  const icon = await fetchFaviconFile()
+  return new Response(icon, {
+    headers: { 'Content-Type': 'image/x-icon' }
+  })
+}
+
+export async function HEAD() { return new Response(null, { status: 200 }) }
+export async function OPTIONS() { return new Response(null, { status: 204 }) }
+```


### PR DESCRIPTION
# Favicon API Routes

## Description
This PR documents the conversion of static `favicon.ico` files to API Route Handlers in complex routing architectures.

## Changes
- **Favicon API Route**: Documentation on implementing `app/favicon.ico/route.ts`.
- **Crawler Compatibility**: Recommended export of `GET`, `HEAD`, and `OPTIONS` handlers to ensure web crawlers and cross-origin checks remain safe.

## Rationale
Static assets can sometimes be problematic in specific monorepo routing or deployment configurations (e.g. edge proxies). When converting to an API route, missing the recommended `HEAD` or `OPTIONS` methods can lead to indexing or asset-discovery errors by crawlers.
