### PR TITLE
docs(error): add _error renaming pattern for unused parameters

### DIFF
--- a/skills/next-best-practices/SKILL.md
+++ b/skills/next-best-practices/SKILL.md
@@ -60,6 +60,7 @@ See [error-handling.md](./error-handling.md) for:
 - `redirect`, `permanentRedirect`, `notFound`
 - `forbidden`, `unauthorized` (auth errors)
 - `unstable_rethrow` for catch blocks
+- Unused error parameter renaming (`_error`)
 
 ## Data Patterns
 

--- a/skills/next-best-practices/error-handling.md
+++ b/skills/next-best-practices/error-handling.md
@@ -225,3 +225,31 @@ app/
 │       └── page.tsx
 └── layout.tsx          # Errors here go to global-error.tsx
 ```
+
+---
+
+# Linting & Unused Parameters
+
+In monorepos with strict ESLint rules (like `@typescript-eslint/no-unused-vars`), empty `catch` blocks or unused error parameters can cause build failures.
+
+## Unused Error Parameter
+
+If you catch an error but don't need to use the `error` object (e.g., if you're just returning a generic failure message), rename the parameter to `_error`.
+
+```tsx
+// Bad: 'error' is defined but never used (ESLint error)
+try {
+  await db.save(data)
+} catch (error) {
+  return { success: false, message: 'Save failed' }
+}
+
+// Good: Renaming to '_error' satisfies the linter while keeping the catch block safe
+try {
+  await db.save(data)
+} catch (_error) {
+  return { success: false, message: 'Save failed' }
+}
+```
+
+**Tip:** In modern JavaScript/TypeScript (since ES2019), you can also omit the parameter entirely if it's not used: `catch { ... }`. However, renaming to `_error` is often preferred in monorepos to maintain consistency with existing patterns.


### PR DESCRIPTION
# Error Handling & Linting

## Description
This PR adds documentation for the `_error` renaming pattern to satisfy strict monorepo linting rules.

## Changes
- **Unused Parameters**: Documentation on renaming unused catch parameters to `_error`.
- **Pattern Matching**: Example showing how this satisfies `@typescript-eslint/no-unused-vars` while maintaining code readability and safe error handling.

## Rationale
Many enterprise-scale monorepos enforce strict linting that prevents unused variables. In scenarios where an error is caught but not used (e.g. returning a generic UI failure message), the `_error` prefix is the standard convention to bypass these checks without compromising safety.
