### PR TITLE
docs(bundling): document standalone output tracing excludes

### DIFF
--- a/skills/next-best-practices/SKILL.md
+++ b/skills/next-best-practices/SKILL.md
@@ -109,6 +109,7 @@ See [bundling.md](./bundling.md) for:
 - Polyfills (already included)
 - ESM/CommonJS issues
 - Bundle analysis
+- Standalone output tracing excludes
 
 ## Scripts
 

--- a/skills/next-best-practices/bundling.md
+++ b/skills/next-best-practices/bundling.md
@@ -178,3 +178,40 @@ module.exports = {
 ```
 
 Reference: https://nextjs.org/docs/app/building-your-application/upgrading/from-webpack-to-turbopack
+
+---
+
+# Standalone Output Tracing
+
+When using `output: 'standalone'` in a monorepo, Next.js attempts to trace and copy all necessary dependencies into the `.next/standalone` folder.
+
+## Excluding Problematic Dependencies
+
+If certain packages (e.g., native mobile dependencies, large assets, or broken symlinks) cause the build to crash during the tracing/copying phase, exclude them using `outputFileTracingExcludes`.
+
+```js
+// next.config.mjs
+
+// Bad: Relying on default tracing if it crashes on native dependencies
+export default {
+  output: 'standalone',
+}
+
+// Good: Explicitly excluding problematic paths or patterns from tracing
+/** @type {import('next').NextConfig} */
+export default {
+  output: 'standalone',
+  experimental: {
+    // Exclude native bindings or mobile-only packages that crash the bundler
+    outputFileTracingExcludes: {
+      '*': [
+        'node_modules/@react-native-community/netinfo',
+        'node_modules/react-native-device-info',
+        '**/*.map', // Also exclude source maps to reduce bundle size
+      ],
+    },
+  },
+}
+```
+
+Reference: https://nextjs.org/docs/app/api-reference/next-config-js/output#automatically-copying-traced-files


### PR DESCRIPTION
# Standalone Output Tracing

## Description
This PR adds documentation for handling problematic dependencies in standalone builds via `outputFileTracingExcludes`.

## Changes
- **Tracing Excludes**: Documentation on excluding native bindings or mobile-only packages from the Next.js standalone output tracing.
- **Configuration Example**: Practical example using `next.config.mjs` to prevent build-time crashes during the asset-copying phase.

## Rationale
When using `output: 'standalone'` in a monorepo that shares code with mobile apps, Next.js often attempts to trace and copy native dependencies that are not relevant to the web build. This frequently results in "file not found" crashes during the build phase; explicit excludes are the recommended fix for these environments.
