### PR TITLE
fix: correct react skill install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npx skills add vercel-labs/next-skills --skill next-cache-components
 For React-specific patterns (hooks, state management, component composition):
 
 ```bash
-npx skills add vercel-labs/agent-skills --skill react-best-practices
+npx skills add vercel-labs/agent-skills --skill vercel-react-best-practices
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary

Fix the `agent-skills` install command in the README's Related Skills section.

The README currently references:

```bash
npx skills add vercel-labs/agent-skills --skill react-best-practices
```

But the published skill name is now:

```bash
npx skills add vercel-labs/agent-skills --skill vercel-react-best-practices
```

This naming change was introduced in vercel-labs/agent-skills@f0ffc95472fad8ce328995f9702797957f3bd40e.

## Related

- Closes #9