### PR TITLE
Leave a 'skills moved' pointer instead of an empty repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Next.js Agent Skills have moved
+
+The skills previously in this repository now live in the Next.js repo:
+https://github.com/vercel/next.js/tree/canary/skills
+
+Install: `npx skills add vercel/next.js`
+
+See [README.md](./README.md) for where each old skill went.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Instructions
+
+The skills here have moved to https://github.com/vercel/next.js/tree/canary/skills
+
+See [AGENTS.md](./AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Next.js Agent Skills have moved
+
+The Next.js agent skills that used to live here now live in the Next.js
+repository, so they stay version-matched with the framework instead of
+drifting in a separate repo.
+
+New home: https://github.com/vercel/next.js/tree/canary/skills
+
+## Install from the new location
+
+```bash
+# Current Next.js workflow skills
+npx skills add vercel/next.js
+
+# Or a specific skill
+npx skills add vercel/next.js --skill next-cache-components-optimizer
+```
+
+Browse the directory above for the current list.
+
+## Where each old skill went
+
+Skills were split by type. Workflow skills still install via `npx skills`.
+Reference knowledge is now delivered automatically through Next.js bundled
+docs (`next/dist/docs/`) and the `AGENTS.md` / `CLAUDE.md` agent rules that
+`next dev` generates (Next.js 16.3+), so it no longer ships as a skill.
+
+- **`next-cache-components`** moved to two workflow skills:
+  `next-cache-components-optimizer` and `next-cache-components-adoption`.
+  Install them from the new location above.
+- **`next-best-practices`** is no longer a skill. This knowledge is now
+  delivered through the bundled docs and the auto-generated `AGENTS.md` /
+  `CLAUDE.md` written by `next dev` (Next.js 16.3+). No separate install.
+- **`next-upgrade`** is no longer a skill. Migration guides ship in the
+  bundled docs; run `npx @next/codemod@latest upgrade` to upgrade.
+
+## Already installed the old skills?
+
+Your local copies still work, but will not receive updates. Re-install from
+the new location to stay current.


### PR DESCRIPTION
Stacked on #21, which removes the skills from this repo but also deletes `README.md`, `AGENTS.md`, and `CLAUDE.md` — leaving an empty repo with no pointer to where the skills went.

This restores those three files as a redirect to `vercel/next.js/skills`. The workflow skills install via `npx skills add vercel/next.js` (`next-cache-components` is now `next-cache-components-optimizer` + `next-cache-components-adoption`), while `next-best-practices` and `next-upgrade` are no longer skills — that knowledge now ships in the bundled docs and the `AGENTS.md`/`CLAUDE.md` that `next dev` generates.