### PR TITLE
Point Next.js 16.1 and earlier users to the manual `agents-md` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ docs (`next/dist/docs/`) and the `AGENTS.md` / `CLAUDE.md` agent rules that
 - **`next-upgrade`** is no longer a skill. Migration guides ship in the
   bundled docs; run `npx @next/codemod@latest upgrade` to upgrade.
 
+## On Next.js 16.1 or earlier?
+
+The auto-generated `AGENTS.md` / `CLAUDE.md` require Next.js 16.3+. On older
+versions you can still get the version-matched docs — pull them into your
+project manually:
+
+```bash
+npx @next/codemod@canary agents-md
+```
+
+This downloads the bundled docs to `.next-docs/` and points your `AGENTS.md`
+at them. See [Set up your Next.js project for AI coding agents](https://nextjs.org/docs/app/guides/ai-agents)
+for the full setup.
+
 ## Already installed the old skills?
 
 Your local copies still work, but will not receive updates. Re-install from


### PR DESCRIPTION
The README says the retired reference knowledge now ships via the auto-generated `AGENTS.md` / `CLAUDE.md`, but that path only exists on Next.js 16.3+. Older versions had no listed way to get the version-matched docs. Adds a section pointing them at `npx @next/codemod@canary agents-md`, which downloads the docs to `.next-docs/`, and links the [AI coding agents guide](https://nextjs.org/docs/app/guides/ai-agents).